### PR TITLE
Use fhiclcpp in favor of fhiclcppsimple

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,17 +24,12 @@ LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 include(CPM)
 
 find_package(ROOT 6.10 REQUIRED)
-
-CPMFindPackage(
-    NAME fhiclcppsimple
-    GIT_TAG feature/jskim_fhiclcpp_to_fhiclcppsimple
-    GITHUB_REPOSITORY jedori0228/fhiclcpp-simple
-)
+find_package(fhiclcpp 4.17.00 REQUIRED)
 
 ###### Compiler set up
 add_library(systematicstools_dependencies INTERFACE)
 target_link_libraries(systematicstools_dependencies INTERFACE 
-  fhiclcppsimple::includes)
+  fhiclcpp::fhiclcpp)
 target_include_directories(systematicstools_dependencies INTERFACE 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
   $<INSTALL_INTERFACE:include> )

--- a/src/systematicstools/interface/FHiCLSystParamHeaderConverters.cc
+++ b/src/systematicstools/interface/FHiCLSystParamHeaderConverters.cc
@@ -4,14 +4,14 @@
 
 #include "systematicstools/interface/types.hh"
 
-#include "fhiclcppsimple/ParameterSet.h"
+#include "fhiclcpp/ParameterSet.h"
 
 #include <vector>
 #include <iomanip>
 
 namespace systtools {
 
-SystParamHeader FHiCLToSystParamHeader(fhiclsimple::ParameterSet const &paramset) {
+SystParamHeader FHiCLToSystParamHeader(fhicl::ParameterSet const &paramset) {
 
   static std::vector<std::string> allowed_keys = {"prettyName",
                                                   "systParamId",
@@ -34,7 +34,7 @@ SystParamHeader FHiCLToSystParamHeader(fhiclsimple::ParameterSet const &paramset
     if (std::find(allowed_keys.begin(), allowed_keys.end(), key) ==
         allowed_keys.end()) {
       throw invalid_SystParamHeader_key()
-          << "[ERROR]: When parsing fhiclsimple::ParameterSet as a "
+          << "[ERROR]: When parsing fhicl::ParameterSet as a "
              "systtools::SystParamHeader, encountered key "
           << std::quoted(key) << " which was not expected.";
     }
@@ -62,8 +62,8 @@ SystParamHeader FHiCLToSystParamHeader(fhiclsimple::ParameterSet const &paramset
   return sph;
 }
 
-fhiclsimple::ParameterSet SystParamHeaderToFHiCL(SystParamHeader const &sph) {
-  fhiclsimple::ParameterSet ps;
+fhicl::ParameterSet SystParamHeaderToFHiCL(SystParamHeader const &sph) {
+  fhicl::ParameterSet ps;
 
   if (!Validate(sph)) {
     (void)Validate(sph, false);

--- a/src/systematicstools/interface/FHiCLSystParamHeaderConverters.hh
+++ b/src/systematicstools/interface/FHiCLSystParamHeaderConverters.hh
@@ -1,26 +1,24 @@
 #pragma once
 
 #include "systematicstools/utility/exceptions.hh"
+#include "fhiclcpp/fwd.h"
 
 #include <string>
 
-namespace fhiclsimple {
-class ParameterSet;
-}
 namespace systtools {
 struct SystParamHeader;
 }
 
 namespace systtools {
 
-/// Exception thrown when an unexpected key is found in a fhiclsimple::ParameterSet
+/// Exception thrown when an unexpected key is found in a fhicl::ParameterSet
 /// being parsed as a SystParamHeader
 NEW_SYSTTOOLS_EXCEPT(invalid_SystParamHeader_key);
 
 ///\brief Deserializes a SystParamHeader instance from a passed FHiCL parameter
 /// set.
-SystParamHeader FHiCLToSystParamHeader(fhiclsimple::ParameterSet const &paramset);
+SystParamHeader FHiCLToSystParamHeader(fhicl::ParameterSet const &paramset);
 
 ///\brief Serializes a SyhstParamHeader instance to a FHiCL table.
-fhiclsimple::ParameterSet SystParamHeaderToFHiCL(SystParamHeader const &sph);
+fhicl::ParameterSet SystParamHeaderToFHiCL(SystParamHeader const &sph);
 }

--- a/src/systematicstools/interface/ISystProviderTool.cc
+++ b/src/systematicstools/interface/ISystProviderTool.cc
@@ -2,7 +2,7 @@
 
 namespace systtools {
 
-ISystProviderTool::ISystProviderTool(fhiclsimple::ParameterSet const &ps)
+ISystProviderTool::ISystProviderTool(fhicl::ParameterSet const &ps)
     : fToolType{ps.get<std::string>("tool_type")}, fSeedSuggestion{0},
       fIsFullyConfigured{false}, fHaveSystMetaData{false} {
   if (!ps.has_key("instance_name")) {
@@ -35,7 +35,7 @@ void ISystProviderTool::SuggestParameterThrows(parameter_throws_list_t &&,
       << ", but it doesn't handle suggested throws.";
 }
 
-void ISystProviderTool::ConfigureFromToolConfig(fhiclsimple::ParameterSet const &ps,
+void ISystProviderTool::ConfigureFromToolConfig(fhicl::ParameterSet const &ps,
                                                 paramId_t firstId) {
   fSystMetaData = this->BuildSystMetaData(ps, firstId);
 
@@ -63,11 +63,11 @@ SystMetaData const &ISystProviderTool::GetSystMetaData() const{
   return fSystMetaData;
 }
 
-fhiclsimple::ParameterSet ISystProviderTool::GetParameterHeadersDocument() {
+fhicl::ParameterSet ISystProviderTool::GetParameterHeadersDocument() {
 
   CheckHaveMetaData();
 
-  fhiclsimple::ParameterSet ParamHeadersDoc;
+  fhicl::ParameterSet ParamHeadersDoc;
   std::vector<std::string> HeaderKeys;
   for (auto &hdr : GetSystMetaData()) {
     ParamHeadersDoc.put(hdr.prettyName, SystParamHeaderToFHiCL(hdr));
@@ -78,7 +78,7 @@ fhiclsimple::ParameterSet ISystProviderTool::GetParameterHeadersDocument() {
   if (GetInstanceName().size()) {
     ParamHeadersDoc.put("instance_name", GetInstanceName());
   }
-  fhiclsimple::ParameterSet ToolOptions = GetExtraToolOptions();
+  fhicl::ParameterSet ToolOptions = GetExtraToolOptions();
   if (!ToolOptions.is_empty()) {
     ParamHeadersDoc.put("tool_options", ToolOptions);
   }
@@ -87,17 +87,17 @@ fhiclsimple::ParameterSet ISystProviderTool::GetParameterHeadersDocument() {
 }
 
 bool ISystProviderTool::ConfigureFromParameterHeaders(
-    fhiclsimple::ParameterSet const &ps) {
+    fhicl::ParameterSet const &ps) {
   std::vector<std::string> const &ParamHeaderNames =
       ps.get<std::vector<std::string>>("parameter_headers");
 
   for (auto const &paramName : ParamHeaderNames) {
     fSystMetaData.emplace_back(
-        FHiCLToSystParamHeader(ps.get<fhiclsimple::ParameterSet>(paramName)));
+        FHiCLToSystParamHeader(ps.get<fhicl::ParameterSet>(paramName)));
   }
   fHaveSystMetaData = true;
 
-  fhiclsimple::ParameterSet ToolOptions;
+  fhicl::ParameterSet ToolOptions;
   ps.get_if_present("tool_options", ToolOptions);
 
   fIsFullyConfigured = this->SetupResponseCalculator(ToolOptions);

--- a/src/systematicstools/interface/ISystProviderTool.hh
+++ b/src/systematicstools/interface/ISystProviderTool.hh
@@ -6,7 +6,7 @@
 
 #include "systematicstools/utility/exceptions.hh"
 
-#include "fhiclcppsimple/ParameterSet.h"
+#include "fhiclcpp/ParameterSet.h"
 
 #include <iomanip>
 #include <iostream>
@@ -26,7 +26,7 @@ NEW_SYSTTOOLS_EXCEPT(invalid_ToolOptions);
 class ISystProviderTool {
 public:
 
-  ISystProviderTool(fhiclsimple::ParameterSet const &ps);
+  ISystProviderTool(fhicl::ParameterSet const &ps);
 
   ///\brief Check if instance handles parameter
   ///
@@ -66,8 +66,8 @@ public:
 
   ///\brief Sub-classes may override this method to provide an example Tool
   /// Configuration FHiCL document.
-  virtual fhiclsimple::ParameterSet GetExampleToolConfiguration() {
-    fhiclsimple::ParameterSet ex_cfg;
+  virtual fhicl::ParameterSet GetExampleToolConfiguration() {
+    fhicl::ParameterSet ex_cfg;
     ex_cfg.put<std::string>("tool_type", GetToolType());
     return ex_cfg;
   }
@@ -81,7 +81,7 @@ public:
   ///
   /// Validates that the SystParamHeaders created by the subclass in
   /// `BuildSystMetaData` are contiguous.
-  void ConfigureFromToolConfig(fhiclsimple::ParameterSet const &ps,
+  void ConfigureFromToolConfig(fhicl::ParameterSet const &ps,
                                paramId_t firstId);
 
   ///\brief Gets the currently configured set of systematic parameter headers.
@@ -95,7 +95,7 @@ public:
   ///
   /// If a sub-class requires extra configuration options they should be exposed
   /// through GetExtraToolOptions
-  fhiclsimple::ParameterSet GetParameterHeadersDocument();
+  fhicl::ParameterSet GetParameterHeadersDocument();
 
   ///\brief Try and read parameter configuration from input fhicl file.
   ///
@@ -105,7 +105,7 @@ public:
   ///\note Sub-classes may not alter fSystMetaData during the configure call.
   /// This is checked for by md5-ing the stringified fhicl representation of the
   /// parameters before and after the call.
-  bool ConfigureFromParameterHeaders(fhiclsimple::ParameterSet const &ps);
+  bool ConfigureFromParameterHeaders(fhicl::ParameterSet const &ps);
 
   //==== return 1-filled event_unit_response_t
   systtools::event_unit_response_t GetDefaultEventResponse() const;
@@ -123,14 +123,14 @@ public:
 protected:
   ///\brief Convert tool-specific configuration fhicl parameter set into generic
   /// SystParamHeaders.
-  virtual SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  virtual SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                          paramId_t) = 0;
 
   ///\brief Gets any extra tool options generated during
   /// ConfigureFromToolConfig that aren't de-serializable to the SystParamHeader
   /// format.
-  virtual fhiclsimple::ParameterSet GetExtraToolOptions() {
-    return fhiclsimple::ParameterSet();
+  virtual fhicl::ParameterSet GetExtraToolOptions() {
+    return fhicl::ParameterSet();
   }
 
   ///\brief Any further configuration required by a subclass before
@@ -143,7 +143,7 @@ protected:
   /// Configuration returned by GetExtraToolOptions after initial Tool
   /// Configuration will be passed into here during
   /// ConfigureFromParameterHeaders
-  virtual bool SetupResponseCalculator(fhiclsimple::ParameterSet const &) = 0;
+  virtual bool SetupResponseCalculator(fhicl::ParameterSet const &) = 0;
 
   ///\brief Checks if internal parameter metadata has been generated or loaded
   /// from a Parameter Headers file.

--- a/src/systematicstools/systproviders/ExampleISystProvider_tool.cc
+++ b/src/systematicstools/systproviders/ExampleISystProvider_tool.cc
@@ -6,7 +6,7 @@
 #include "systematicstools/utility/string_parsers.hh"
 
 using namespace systtools;
-using namespace fhiclsimple;
+using namespace fhicl;
 
 // 1 sigma = 5% normalisation uncertainty by default.
 double default_centralvalue_nu = 1;

--- a/src/systematicstools/systproviders/ExampleISystProvider_tool.hh
+++ b/src/systematicstools/systproviders/ExampleISystProvider_tool.hh
@@ -8,12 +8,12 @@
 
 class ExampleISystProvider : public systtools::ISystProviderTool {
 public:
-  explicit ExampleISystProvider(fhiclsimple::ParameterSet const &);
+  explicit ExampleISystProvider(fhicl::ParameterSet const &);
 
-  systtools::SystMetaData BuildSystMetaData(fhiclsimple::ParameterSet const &,
+  systtools::SystMetaData BuildSystMetaData(fhicl::ParameterSet const &,
                                           systtools::paramId_t);
-  fhiclsimple::ParameterSet GetExtraToolOptions();
-  bool SetupResponseCalculator(fhiclsimple::ParameterSet const &);
+  fhicl::ParameterSet GetExtraToolOptions();
+  bool SetupResponseCalculator(fhicl::ParameterSet const &);
 
   std::string AsString();
 
@@ -22,4 +22,3 @@ private:
   std::unique_ptr<std::mt19937_64> RNgine;
   std::unique_ptr<std::normal_distribution<double>> RNJesus;
 };
-

--- a/src/systematicstools/utility/FHiCLSystParamHeaderUtility.cc
+++ b/src/systematicstools/utility/FHiCLSystParamHeaderUtility.cc
@@ -5,7 +5,7 @@
 #include "systematicstools/interface/SystMetaData.hh"
 #include "systematicstools/interface/types.hh"
 
-#include "fhiclcppsimple/ParameterSet.h"
+#include "fhiclcpp/ParameterSet.h"
 
 #include <chrono>
 #include <functional>
@@ -16,7 +16,7 @@
 
 namespace systtools {
 
-bool ParseFHiCLVariationDescriptor(fhiclsimple::ParameterSet const &paramset,
+bool ParseFHiCLVariationDescriptor(fhicl::ParameterSet const &paramset,
                                    std::string const &CV_key,
                                    std::string const &vardescriptor_key,
                                    SystParamHeader &hdr) {
@@ -101,7 +101,7 @@ bool ParseFHiCLVariationDescriptor(fhiclsimple::ParameterSet const &paramset,
   return true;
 }
 
-bool MakeFHiCLDefinedRandomVariations(fhiclsimple::ParameterSet const &paramset,
+bool MakeFHiCLDefinedRandomVariations(fhicl::ParameterSet const &paramset,
                                       std::string const &nthrows_key,
                                       SystParamHeader &hdr,
                                       std::string const &distribution_key,
@@ -151,8 +151,8 @@ bool MakeFHiCLDefinedRandomVariations(fhiclsimple::ParameterSet const &paramset,
   return true;
 }
 
-bool FHiCLSimpleToolConfigurationParameterExists(
-    fhiclsimple::ParameterSet const &paramset, std::string const &parameter_name) {
+bool FhiclToolConfigurationParameterExists(
+    fhicl::ParameterSet const &paramset, std::string const &parameter_name) {
 
   std::string CV_key = parameter_name + "_central_value";
   std::string Tweak_key = parameter_name + "_variation_descriptor";
@@ -166,8 +166,8 @@ bool FHiCLSimpleToolConfigurationParameterExists(
   return false;
 }
 
-bool ParseFHiCLSimpleToolConfigurationParameter(
-    fhiclsimple::ParameterSet const &paramset, std::string const &parameter_name,
+bool ParseFhiclToolConfigurationParameter(
+    fhicl::ParameterSet const &paramset, std::string const &parameter_name,
     SystParamHeader &hdr, uint64_t seed, size_t NThrows) {
 
   std::string CV_key = parameter_name + "_central_value";

--- a/src/systematicstools/utility/FHiCLSystParamHeaderUtility.hh
+++ b/src/systematicstools/utility/FHiCLSystParamHeaderUtility.hh
@@ -1,12 +1,10 @@
 #pragma once
 
 #include "systematicstools/utility/exceptions.hh"
+#include "fhiclcpp/fwd.h"
 
 #include <string>
 
-namespace fhiclsimple {
-class ParameterSet;
-}
 namespace systtools {
 struct SystParamHeader;
 }
@@ -39,7 +37,7 @@ NEW_SYSTTOOLS_EXCEPT(invalid_FHiCL_random_distribution_descriptor);
 ///   - SystParamHeader::paramVariations = {5, 3, 1, 4}
 ///
 /// throws invalid_FHiCL_variation_descriptor on error
-bool ParseFHiCLVariationDescriptor(fhiclsimple::ParameterSet const &paramset,
+bool ParseFHiCLVariationDescriptor(fhicl::ParameterSet const &paramset,
                                    std::string const &CV_key,
                                    std::string const &vardescriptor_key,
                                    SystParamHeader &hdr);
@@ -58,7 +56,7 @@ bool ParseFHiCLVariationDescriptor(fhiclsimple::ParameterSet const &paramset,
 /// found in paramset and the NThrows argument is 0, hdr is not modified.
 ///
 /// If no seed is passed, the current time will be used.
-bool MakeFHiCLDefinedRandomVariations(fhiclsimple::ParameterSet const &paramset,
+bool MakeFHiCLDefinedRandomVariations(fhicl::ParameterSet const &paramset,
                                       std::string const &nthrows_key,
                                       SystParamHeader &hdr,
                                       std::string const &distribution_key = "",
@@ -70,8 +68,8 @@ bool MakeFHiCLDefinedRandomVariations(fhiclsimple::ParameterSet const &paramset,
 /// If either "<parameter_name>_central_value" or
 /// "<parameter_name>_variation_descriptor" exist, the parameter named
 /// <parameter_name> is considered to exist in the configuration.
-bool FHiCLSimpleToolConfigurationParameterExists(
-    fhiclsimple::ParameterSet const &paramset, std::string const &parameter_name);
+bool FhiclToolConfigurationParameterExists(
+    fhicl::ParameterSet const &paramset, std::string const &parameter_name);
 
 ///\brief Builds SystParamHeader from standardized FHiCL that can be used to
 /// write Tool Configuration files.
@@ -90,8 +88,8 @@ bool FHiCLSimpleToolConfigurationParameterExists(
 /// }
 ///
 /// Uses ParseFHiCLVariationDescriptor and MakeFHiCLDefinedRandomVariations
-bool ParseFHiCLSimpleToolConfigurationParameter(
-    fhiclsimple::ParameterSet const &paramset, std::string const &parameter_name,
+bool ParseFhiclToolConfigurationParameter(
+    fhicl::ParameterSet const &paramset, std::string const &parameter_name,
     SystParamHeader &hdr, uint64_t seed = 0, size_t NThrows = 0);
 
 } // namespace systtools

--- a/src/systematicstools/utility/ParameterAndProviderConfigurationUtility.cc
+++ b/src/systematicstools/utility/ParameterAndProviderConfigurationUtility.cc
@@ -9,7 +9,7 @@
 
 namespace systtools {
 
-param_header_map_t BuildParameterHeaders(fhiclsimple::ParameterSet const &paramset,
+param_header_map_t BuildParameterHeaders(fhicl::ParameterSet const &paramset,
                                          std::string const &key) {
 
   param_header_map_t headers;
@@ -17,7 +17,7 @@ param_header_map_t BuildParameterHeaders(fhiclsimple::ParameterSet const &params
   // Foreach provider block
   auto const &provider_keys = paramset.get<std::vector<std::string>>(key);
   for (auto const &provkey : provider_keys) {
-    auto const &provider_cfg = paramset.get<fhiclsimple::ParameterSet>(provkey);
+    auto const &provider_cfg = paramset.get<fhicl::ParameterSet>(provkey);
 
     std::string provname = provider_cfg.get<std::string>("tool_type");
     if (provider_cfg.has_key("instance_name")) {
@@ -30,7 +30,7 @@ param_header_map_t BuildParameterHeaders(fhiclsimple::ParameterSet const &params
     // Foreach handled parameter block
     for (auto const &ParamHeaderKey : ParameterHeaderKeyNames) {
       SystParamHeader hdr = FHiCLToSystParamHeader(
-          provider_cfg.get<fhiclsimple::ParameterSet>(ParamHeaderKey));
+          provider_cfg.get<fhicl::ParameterSet>(ParamHeaderKey));
 
       // Check that this unique Id hasn't been used before.
       if (headers.find(hdr.systParamId) != headers.end()) {

--- a/src/systematicstools/utility/ParameterAndProviderConfigurationUtility.hh
+++ b/src/systematicstools/utility/ParameterAndProviderConfigurationUtility.hh
@@ -6,7 +6,7 @@
 
 #include "systematicstools/utility/exceptions.hh"
 
-#include "fhiclcppsimple/ParameterSet.h"
+#include "fhiclcpp/ParameterSet.h"
 
 #include <chrono>
 #include <functional>
@@ -26,7 +26,7 @@ NEW_SYSTTOOLS_EXCEPT(ISystProvider_FQName_collision);
 /// Used by standalone interpreters to read response interpretation metadata
 /// from input FHiCL
 param_header_map_t
-BuildParameterHeaders(fhiclsimple::ParameterSet const &paramset,
+BuildParameterHeaders(fhicl::ParameterSet const &paramset,
                       std::string const &key = "syst_providers");
 
 ///\brief Builds map of SystProvider instances and handled parameters from a
@@ -65,8 +65,8 @@ param_header_map_t BuildParameterHeaders(
 /// art, other instantiators must be used.
 template <typename T = systtools::ISystProviderTool>
 std::vector<std::unique_ptr<T>> ConfigureISystProvidersFromToolConfig(
-    fhiclsimple::ParameterSet const &paramset,
-    std::function<std::unique_ptr<T>(fhiclsimple::ParameterSet const &)> InstanceBuilder,
+    fhicl::ParameterSet const &paramset,
+    std::function<std::unique_ptr<T>(fhicl::ParameterSet const &)> InstanceBuilder,
     std::string const &key = "syst_providers", paramId_t syst_param_id = 0) {
 
   // Instantiate RNGs for seed suggestion.
@@ -79,7 +79,7 @@ std::vector<std::unique_ptr<T>> ConfigureISystProvidersFromToolConfig(
 
   for (auto const &provkey : paramset.get<std::vector<std::string>>(key)) {
     // Get fhicl config for provider
-    auto const &provider_cfg = paramset.get<fhiclsimple::ParameterSet>(provkey);
+    auto const &provider_cfg = paramset.get<fhicl::ParameterSet>(provkey);
 
     // Make an instance of the plugin
     std::unique_ptr<T> is = InstanceBuilder(provider_cfg);
@@ -122,15 +122,15 @@ std::vector<std::unique_ptr<T>> ConfigureISystProvidersFromToolConfig(
 /// art, other instantiators must be used.
 template <typename T = systtools::ISystProviderTool>
 std::vector<std::unique_ptr<T>> ConfigureISystProvidersFromParameterHeaders(
-    fhiclsimple::ParameterSet const &paramset,
-    std::function<std::unique_ptr<T>(fhiclsimple::ParameterSet const &)> InstanceBuilder,
+    fhicl::ParameterSet const &paramset,
+    std::function<std::unique_ptr<T>(fhicl::ParameterSet const &)> InstanceBuilder,
     std::string const &key = "syst_providers") {
 
   std::vector<std::unique_ptr<T>> providers;
 
   for (auto const &provkey : paramset.get<std::vector<std::string>>(key)) {
     // Get fhicl config for provider
-    auto const &provider_cfg = paramset.get<fhiclsimple::ParameterSet>(provkey);
+    auto const &provider_cfg = paramset.get<fhicl::ParameterSet>(provkey);
 
     // Make an instance of the plugin
     std::unique_ptr<T> is = InstanceBuilder(provider_cfg);

--- a/src/systematicstools/utility/printers.hh
+++ b/src/systematicstools/utility/printers.hh
@@ -4,7 +4,7 @@
 #include "systematicstools/interface/FHiCLSystParamHeaderConverters.hh"
 #include "systematicstools/interface/SystParamHeader.hh"
 
-#include "fhiclcppsimple/ParameterSet.h"
+#include "fhiclcpp/ParameterSet.h"
 
 #include <iomanip>
 #include <sstream>
@@ -12,7 +12,7 @@
 
 namespace systtools {
 inline std::string to_str(SystParamHeader const &sph, bool indent = true) {
-  fhiclsimple::ParameterSet ps = SystParamHeaderToFHiCL(sph);
+  fhicl::ParameterSet ps = SystParamHeaderToFHiCL(sph);
   return indent ? ps.to_indented_string() : ps.to_string();
 }
 


### PR DESCRIPTION
This PR makes it possible to use `fhiclcpp` without using `cetmodules`.  Because systematicstools is already built in a UPS environment, the only thing that is necessary is to invoke:

`setup fhiclcpp v4_17_00 -q e20:prof`

before invoking `cmake ../systematicstools-src/`.